### PR TITLE
libzippp, fastpfor, gtest all playing nice + bz2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,18 +3,28 @@ cmake_minimum_required(VERSION 3.27)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_INSTALL_PREFIX "./bin")
 
 project(gwas_run)
 
+## Enable bzip2 support in libzippp
+add_definitions(-DZIP_CM_BZIP2)
+
 ## Include directories
 include_directories(include)
-include_directories(lib)
+# include_directories(lib)
 include_directories(lib/googletest/googletest/include)
-#include_directories(lib/FastPFor)
+include_directories(lib/FastPFor/headers)
+include_directories(lib/libzippp/bin/include)
 
 ## Link directories
-add_subdirectory(lib/googletest)
-#add_subdirectory(lib/FastPFor)
+add_subdirectory(lib/libzippp)
+add_subdirectory(lib/FastPFor)
+if(NOT TARGET gmock)
+  # can't be doubly adding.
+  # Note, fastpfor depends on gtest
+  add_subdirectory(lib/googletest)
+endif()
 
 ### Add the executables
 # COMPRESSION
@@ -55,7 +65,7 @@ add_executable(test_gwas
         src/compress.cpp)
 
 # Additional configuration if needed, e.g., linking libraries, "adding -lz"
-target_link_libraries(gwas_compress z)
-target_link_libraries(gwas_index z)
-target_link_libraries(gwas_decompress z)
-target_link_libraries(test_gwas gtest gtest_main z)
+target_link_libraries(gwas_compress libzippp FastPFOR z)
+target_link_libraries(gwas_index libzippp FastPFOR z)
+target_link_libraries(gwas_decompress libzippp FastPFOR z)
+target_link_libraries(test_gwas gtest gtest_main libzippp FastPFOR z)

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+with import <nixpkgs> {};
+stdenv.mkDerivation {
+    name = "dev";
+    buildInputs = [
+      # pkg-config
+      zlib
+      libzip
+      gcc
+      cmake
+      simde
+      bzip2
+    ];
+}

--- a/src/compress.cpp
+++ b/src/compress.cpp
@@ -5,7 +5,7 @@
 #include <sstream>
 #include <stdexcept>
 
-#include "FastPFor/headers/variablebyte.h"
+#include "variablebyte.h"
 
 #include "utils.h"
 #include "header.h"

--- a/src/decompress.cpp
+++ b/src/decompress.cpp
@@ -5,7 +5,7 @@
 #include <sstream>
 #include <stdexcept>
 
-#include "FastPFor/headers/variablebyte.h"
+#include "variablebyte.h"
 
 #include "utils.h"
 #include "header.h"

--- a/test/test_compress.cpp
+++ b/test/test_compress.cpp
@@ -3,7 +3,7 @@
 #include "compress.h"
 #include "decompress.h"
 #include "utils.h"
-#include "googletest/googletest/include/gtest/gtest.h"
+#include "gtest/gtest.h"
 
 using namespace std;
 

--- a/test/test_gwas.cpp
+++ b/test/test_gwas.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include "googletest/googletest/include/gtest/gtest.h"
+#include "gtest/gtest.h"
 
 using namespace std;
 

--- a/test/test_header.cpp
+++ b/test/test_header.cpp
@@ -4,7 +4,7 @@
 #include "header.h"
 #include "compress.h"
 #include "decompress.h"
-#include "googletest/googletest/include/gtest/gtest.h"
+#include "gtest/gtest.h"
 
 using namespace std;
 

--- a/test/test_index.cpp
+++ b/test/test_index.cpp
@@ -2,7 +2,7 @@
 
 #include "index.h"
 #include "decompress.h"
-#include "googletest/googletest/include/gtest/gtest.h"
+#include "gtest/gtest.h"
 
 using namespace std;
 

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
 #include "utils.h"
-#include "googletest/googletest/include/gtest/gtest.h"
+#include "gtest/gtest.h"
 
 using namespace std;
 


### PR DESCRIPTION
Changes to cmake file: more "normally" depending on all related tools. FastPFor depends on gtest in addition to our domestic dependency on gtest; fixed conflict.
Import statements adjusted accordingly.
All tests passing.